### PR TITLE
Replaced respond-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,6 @@ $ tree
 │   └── …
 ├── styles.scss
 └── variables
-    ├── _breakpoints.scss
     ├── _color.scss
     ├── _timing.scss
     ├── _typography.scss
@@ -523,12 +522,10 @@ __List media queries first__
 
 ```
 .b-foo {
-	
 	// Media Queries
-	@include respond-to(desktop) {
+	@include breakpoint(large) {
 		padding: 10px;
 	}
-	
 }
 ```
 
@@ -536,15 +533,13 @@ __List global styles beginning with @extend second (separated by a blank line)__
 
 ```
 .b-foo {
-	
-	// Media Queries
-	@include respond-to(desktop) {
-		padding: 10px;
-	}
-	
 	// Global Styles
 	@extend %module;
-	
+
+	// Media Queries
+	@include breakpoint(large) {
+		padding: 10px;
+	}
 }
 ```
 
@@ -552,16 +547,14 @@ __List @include third__
 
 ```
 .b-foo {
-	
-	// Media Queries
-	@include respond-to(desktop) {
-		padding: 10px;
-	}
-	
 	// Global Styles
 	@extend %module;
 	@include centering(horiz);
 	
+	// Media Queries
+	@include breakpoint(large) {
+		padding: 10px;
+	}
 }
 ```
 
@@ -569,17 +562,15 @@ __List regular styles next__
 
 ```
 .b-foo {
-	
-	// Media Queries
-	@include respond-to(desktop) {
-		padding: 10px;
-	}
-	
 	// Global Styles
 	@extend %module;
 	@include centering(horiz);
 	color: #000;
 	
+	// Media Queries
+	@include breakpoint(large) {
+		padding: 10px;
+	}
 }
 ```
 
@@ -587,12 +578,6 @@ __List pseudo-class/elements nesting with & (separated by a blank line)__
 
 ```
 .b-foo {
-	
-	// Media Queries
-	@include respond-to(desktop) {
-		padding: 10px;
-	}
-	
 	// Global Styles
 	@extend %module;
 	@include centering(horiz);
@@ -606,6 +591,10 @@ __List pseudo-class/elements nesting with & (separated by a blank line)__
 		content: "";
 	}
 	
+	// Media Queries
+	@include breakpoint(large) {
+		padding: 10px;
+	}
 }
 ```
 
@@ -613,9 +602,8 @@ __List nested selectors last (separated by a blank line)__
 
 ```
 .b-foo {
-	
 	// Media Queries
-	@include respond-to(desktop) {
+	@include breakpoint(large) {
 		padding: 10px;
 	}
 	
@@ -635,7 +623,6 @@ __List nested selectors last (separated by a blank line)__
 	> .bar {
 		background-color: #f90;
 	}
-	
 }
 ```
 


### PR DESCRIPTION
Replaced respond-to with breakpoint mixin in SCSS examples and moved them at the end of rule blocks.